### PR TITLE
Support impish and drop hirsute

### DIFF
--- a/debutizer.ppa.yaml
+++ b/debutizer.ppa.yaml
@@ -1,7 +1,7 @@
 distributions:
   - bionic
   - focal
-  - hirsute
+  - impish
 
 upstream:
   url: http://ppa.launchpad.net/velovix/debutizer/ubuntu

--- a/debutizer.prod.yaml
+++ b/debutizer.prod.yaml
@@ -1,7 +1,7 @@
 distributions:
   - bionic
   - focal
-  - hirsute
+  - impish
 
 upstream:
   url: http://apt.debutizer.dev

--- a/debutizer.stage.yaml
+++ b/debutizer.stage.yaml
@@ -1,7 +1,7 @@
 distributions:
   - bionic
   - focal
-  - hirsute
+  - impish
 
 upstream:
   url: http://apt.debutizer.dev


### PR DESCRIPTION
Ubuntu 21.04 (Hirsute) has not been supported for a while and 21.10 (Impish) is now the latest supported version.